### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/svelte-check.yml
+++ b/.github/workflows/svelte-check.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   svelte-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/libersoft-org/yellow-client/security/code-scanning/9](https://github.com/libersoft-org/yellow-client/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function. Based on the tasks performed in the workflow (checking out code, installing dependencies, building files, and running checks), the workflow only requires `contents: read` permissions. Adding this block ensures that the `GITHUB_TOKEN` has limited access, reducing the risk of unintended actions or security vulnerabilities.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
