### PR TITLE
Fix vitest alias resolution

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,8 +14,8 @@ export default defineConfig({
 		alias: {
 			'@/org.libersoft.messages': path.resolve(__dirname, 'src/modules/org.libersoft.messages'),
 			'@/org.libersoft.dating': path.resolve(__dirname, 'src/modules/org.libersoft.dating'),
-			'@': path.resolve(__dirname, 'src'),
 			'@/bridge/core-bridge': path.resolve(__dirname, 'src/modules/org.libersoft.messages/core-bridge-builtin.ts'),
+			'@': path.resolve(__dirname, 'src'),
 		},
 	},
 	define: {


### PR DESCRIPTION
## Summary
- fix alias order in `vitest.config.ts` so `@/bridge/core-bridge` resolves

## Testing
- `npm run test:unit` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845da52a1648329a43aaf36288e5d17